### PR TITLE
Allow Renaming nginx controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ module nginx-ingress-controller {
   version = "0.1.12",
 
   # optional
+  name = "ingress-nginx"
   nginx_config {
     "ssl-protocols"     = "TLSv1.2" # Only Support TLSv1.2
 	"proxy-buffer-size" = "16k"

--- a/lb.tf
+++ b/lb.tf
@@ -1,11 +1,11 @@
 // https://raw.githubusercontent.com/kubernetes/ingress-nginx/nginx-0.29.0/deploy/static/provider/aws/service-nlb.yaml
 resource "kubernetes_service" "lb" {
   metadata {
-    name      = local.name
+    name      = var.name
     namespace = kubernetes_namespace.nginx.metadata.0.name
 
     labels = {
-      "app.kubernetes.io/name"       = local.name
+      "app.kubernetes.io/name"       = var.name
       "app.kubernetes.io/part-of"    = kubernetes_namespace.nginx.metadata.0.name
       "app.kubernetes.io/managed-by" = "terraform"
     }
@@ -16,7 +16,7 @@ resource "kubernetes_service" "lb" {
   spec {
     type = "LoadBalancer"
     selector = {
-      "app.kubernetes.io/name"    = local.name
+      "app.kubernetes.io/name"    = var.name
       "app.kubernetes.io/part-of" = kubernetes_namespace.nginx.metadata.0.name
     }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,7 @@ output "lb_address" {
   value       = length(kubernetes_service.lb.load_balancer_ingress[0].ip) > 0 ? kubernetes_service.lb.load_balancer_ingress[0].ip : kubernetes_service.lb.load_balancer_ingress[0].hostname
   description = "The hostname of the LB created by kubernetes"
 }
+
+output "ingress_class" {
+  value = var.name
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "name" {
+  description = "The name of this nginx ingress controller"
+  type        = string
+  default     = "ingress-nginx"
+}
+
 variable "nginx_ingress_controller_version" {
   description = "The version of Nginx Ingress Controller to use. See https://github.com/kubernetes/ingress-nginx/releases for available versions"
   type        = string


### PR DESCRIPTION
To allow two different nginx controllers to co-exist in the same cluster, I needed to change quite a lot of things. This commit has more effects than just renaming things however - for example, the cluster role bindings are destroyed and recreated when this is applied. This also contains the changes from my other pull request to make it easier to apply.

I'm not sure what the consequences of dropping and recreating the cluster role bindings are. There seems to be no issue continuing to serve traffic while they don't exist, so I assume that the only downtime when applying this new version is that new ingresses won't register until the role bindings are recreated.

Let me know if you have any suggestions.