### PR TITLE
Fix lb_address output for Kubernetes provider 2.0

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "lb_address" {
-  value       = length(kubernetes_service.lb.load_balancer_ingress[0].ip) > 0 ? kubernetes_service.lb.load_balancer_ingress[0].ip : kubernetes_service.lb.load_balancer_ingress[0].hostname
+  value       = length(kubernetes_service.lb.status[0].load_balancer[0].ingress[0].ip) > 0 ? kubernetes_service.lb.status[0].load_balancer[0].ingress[0].ip : kubernetes_service.lb.status[0].load_balancer[0].ingress[0].hostname
   description = "The hostname of the LB created by kubernetes"
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    kubernetes {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.0"
+    }
+  }
+}


### PR DESCRIPTION
The Hashicorp Kubernetes provider recently update to v2. Part of this update removed the `load_balancer_ingress` output from a kubernetes service. This pull updates the output to the v2 as well as setting a minimum version for the kubernetes provider.

When we merge this pull we should at least up the version of this module to 0.2.0